### PR TITLE
add empty handler for /

### DIFF
--- a/internal/app/cloudinfo/api/routes.go
+++ b/internal/app/cloudinfo/api/routes.go
@@ -63,6 +63,7 @@ func (r *RouteHandler) ConfigureRoutes(router *gin.Engine, basePath string) {
 	base := router.Group(basePath)
 
 	{
+		base.GET("/", r.signalEmpty)
 		base.GET("/status", r.signalStatus)
 		base.GET("/version", r.versionHandler)
 	}
@@ -90,6 +91,10 @@ func (r *RouteHandler) ConfigureRoutes(router *gin.Engine, basePath string) {
 
 func (r *RouteHandler) signalStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, "ok")
+}
+
+func (r *RouteHandler) signalEmpty(c *gin.Context) {
+	c.JSON(http.StatusOK, "")
 }
 
 func (r *RouteHandler) versionHandler(c *gin.Context) {


### PR DESCRIPTION
When deployed on stage, cloudinfo is returning 404 for queries to "/". This is the result of removing the front-end, which was responsible of attending that request.

We still don't know who is asking for that path, but I think it is better to return empty content with 200 as it was done before