### PR TITLE
query for product info in all subzones

### DIFF
--- a/internal/cloudinfo/providers/google/cloudinfo.go
+++ b/internal/cloudinfo/providers/google/cloudinfo.go
@@ -343,46 +343,48 @@ func (g *GceInfoer) GetVirtualMachines(region string) ([]types.VMInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = g.computeSvc.MachineTypes.List(g.projectId, zones[0]).Pages(context.TODO(), func(allMts *compute.MachineTypeList) error {
-		for _, mt := range allMts.Items {
-			if _, ok := vmsMap[mt.Name]; !ok {
-				switch {
-				case mt.GuestCpus < 1:
-					// minimum 1 Gbps network performance for each virtual machine
-					ntwPerf = 1
-				case mt.GuestCpus > 8:
-					// theoretical maximum of 16 Gbps for each virtual machine
-					ntwPerf = 16
-				default:
-					// each vCPU has a 2 Gbps egress cap for peak performance
-					ntwPerf = uint(mt.GuestCpus * 2)
-				}
-				ntwMapper := newGceNetworkMapper()
-				ntwPerfCat, err := ntwMapper.MapNetworkPerf(fmt.Sprint(ntwPerf, " Gbit/s"))
-				if err != nil {
-					logger.Debug(emperror.Wrap(err, "failed to get network performance category").Error(),
-						map[string]interface{}{"instanceType": mt.Name})
-				}
-				vmsMap[mt.Name] = types.VMInfo{
-					Category:   g.getCategory(mt.Name),
-					Type:       mt.Name,
-					Cpus:       float64(mt.GuestCpus),
-					Mem:        float64(mt.MemoryMb) / 1024,
-					NtwPerf:    fmt.Sprintf("%d Gbit/s", ntwPerf),
-					NtwPerfCat: ntwPerfCat,
-					Zones:      zones,
-					Attributes: cloudinfo.Attributes(fmt.Sprint(mt.GuestCpus), fmt.Sprint(float64(mt.MemoryMb)/1024), ntwPerfCat, g.getCategory(mt.Name)),
+	var vms []types.VMInfo
+	for _, zone := range zones {
+		err = g.computeSvc.MachineTypes.List(g.projectId, zone).Pages(context.TODO(), func(allMts *compute.MachineTypeList) error {
+			for _, mt := range allMts.Items {
+				if _, ok := vmsMap[mt.Name]; !ok {
+					switch {
+					case mt.GuestCpus < 1:
+						// minimum 1 Gbps network performance for each virtual machine
+						ntwPerf = 1
+					case mt.GuestCpus > 8:
+						// theoretical maximum of 16 Gbps for each virtual machine
+						ntwPerf = 16
+					default:
+						// each vCPU has a 2 Gbps egress cap for peak performance
+						ntwPerf = uint(mt.GuestCpus * 2)
+					}
+					ntwMapper := newGceNetworkMapper()
+					ntwPerfCat, err := ntwMapper.MapNetworkPerf(fmt.Sprint(ntwPerf, " Gbit/s"))
+					if err != nil {
+						logger.Debug(emperror.Wrap(err, "failed to get network performance category").Error(),
+							map[string]interface{}{"instanceType": mt.Name})
+					}
+					vmsMap[mt.Name] = types.VMInfo{
+						Category:   g.getCategory(mt.Name),
+						Type:       mt.Name,
+						Cpus:       float64(mt.GuestCpus),
+						Mem:        float64(mt.MemoryMb) / 1024,
+						NtwPerf:    fmt.Sprintf("%d Gbit/s", ntwPerf),
+						NtwPerfCat: ntwPerfCat,
+						Zones:      zones,
+						Attributes: cloudinfo.Attributes(fmt.Sprint(mt.GuestCpus), fmt.Sprint(float64(mt.MemoryMb)/1024), ntwPerfCat, g.getCategory(mt.Name)),
+					}
 				}
 			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
 		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	var vms []types.VMInfo
-	for _, vm := range vmsMap {
-		vms = append(vms, vm)
+		for _, vm := range vmsMap {
+			vms = append(vms, vm)
+		}
 	}
 	logger.Debug("found virtual machines", map[string]interface{}{"vms": len(vms)})
 	return vms, nil


### PR DESCRIPTION
When cloudinfo request information about the virtual machines in a region for google, it first queries the cloud provider for the subzones of the region that is querying. However, it then only uses the first sub-zone to request the available VM's.

This can lead to VM's that are available in a sub-zone that is not the first one to be omited from the results.

This PR uses all the subzones to request available VM's

Guidelines for testing:
- Deploy and query for the following:
```
curl  -ksL -X GET "http://localhost:8000/api/v1/providers/google/services/compute/regions/us-west1/products" | jq . | grep type | grep c4a
```

Instances of type `c4a` are available in `us-west1-a` but not `us-west1-b` or `c` 