### PR TITLE
Full update and upgrade in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN set -xe && \
 # Final image
 FROM alpine:edge
 
-RUN apk add --update --no-cache ca-certificates tzdata bash curl libcrypto3 libssl3
+RUN apk add --update --no-cache ca-certificates tzdata bash curl
+RUN apk update && apk upgrade
 
 SHELL ["/bin/bash", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN set -xe && \
 # Final image
 FROM alpine:edge
 
-RUN apk add --update --no-cache ca-certificates tzdata bash curl
+RUN apk add --update --no-cache ca-certificates tzdata bash curl libcrypto3 libssl3
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
This PR does a full upgrade of all packages in the alpine docker image before installing cloudinfo. This ensures a more up-to-date image that solves some vulnerabilities detected by trivy (in particular [CVE-2024-12797](https://avd.aquasec.com/nvd/cve-2024-12797) and [CVE-2024-12797](https://avd.aquasec.com/nvd/cve-2024-12797) at the time this PR was created).