### PR TITLE
FSN-421: Remove actions/cache due to decommission

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.22
   GOFLAGS: -mod=readonly
 
 jobs:
@@ -26,20 +25,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v3.1.0
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Cache Go module dependencies
-        id: cache-go-module-dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: go-mod-cache-${{ runner.os }}-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-mod-cache-${{ runner.os }}-${{ env.GO_VERSION }}
-            go-mod-cache-${{ runner.os }}
-            go-mod-cache
+          go-version-file: 'go.mod'
 
       - name: Build binaries and libraries
         run: make build
@@ -53,20 +41,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Go
-        uses: actions/setup-go@v3.1.0
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Restore Go module dependencies cache
-        id: cache-go-module-dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: go-mod-cache-${{ runner.os }}-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-mod-cache-${{ runner.os }}-${{ env.GO_VERSION }}
-            go-mod-cache-${{ runner.os }}
-            go-mod-cache
+          go-version-file: 'go.mod'
 
       - name: Run unit tests
         run: make test
@@ -80,20 +57,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Go
-        uses: actions/setup-go@v3.1.0
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Restore Go module dependencies cache
-        id: cache-go-module-dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: go-mod-cache-${{ runner.os }}-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-mod-cache-${{ runner.os }}-${{ env.GO_VERSION }}
-            go-mod-cache-${{ runner.os }}
-            go-mod-cache
+          go-version-file: 'go.mod'
 
       - name: Set up test environment
         run: make up

--- a/internal/app/cloudinfo/cistore/cassandra_test.go
+++ b/internal/app/cloudinfo/cistore/cassandra_test.go
@@ -37,7 +37,7 @@ func testCassandraStore(t *testing.T) {
 		cloudinfoadapter.NewLogger(&logur.TestLogger{}),
 	)
 
-	ctx, cancelFunction := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancelFunction := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFunction()
 loop:
 	for {


### PR DESCRIPTION
GitHub action `actions/cache` deprecated versions earlier than 3, and decommissioned them starting February 1st, causing out pipeline to fail. See https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down. This action is used to cache golang dependencies, however the actions/setup-go offers caching capabilities natively, so we can rely on that instead to simplify the workflow. A side effect of a working chaching is that tests start executing faster, so we need to increase the deadline of integration test execution, to wait for the docker service dependencies to be up and running.